### PR TITLE
No capturePanel dropdown on "Pooled Library"

### DIFF
--- a/frontend/src/components/Upload/UploadForm.js
+++ b/frontend/src/components/Upload/UploadForm.js
@@ -38,7 +38,8 @@ class UploadForm extends React.Component {
     };
 
     showCapturePanelDropdown = () => {
-        return this.state.values.application === 'CustomCapture';
+        return this.state.values.application === 'CustomCapture' &&
+            this.state.values.material !== 'Pooled Library';
     };
     showPatientIdTypeSpecDropdown = () => {
         return (


### PR DESCRIPTION
Users who submit pooled libraries do not have custom panels (e.g. Grittney)