### PR TITLE
Sd/fix/handle large requests

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -88,6 +88,5 @@ const server = http.createServer(app);
 server.listen(port, hostname, () => {
     console.log(`Server running at http://${hostname}:${port}/`);
 });
-server.timeout = 240000;
 
 module.exports = server;

--- a/api/server.js
+++ b/api/server.js
@@ -74,6 +74,7 @@ app.use('/api/', apiRouter);
 app.get('/', function (req, res) {
     res.sendFile(path.join(publicDir, 'index.html'));
 });
+
 app.get('/favicon.ico', function (req, res) {
     res.sendFile(path.join(publicDir, 'favicon.ico'));
 });
@@ -87,5 +88,6 @@ const server = http.createServer(app);
 server.listen(port, hostname, () => {
     console.log(`Server running at http://${hostname}:${port}/`);
 });
+server.timeout = 240000;
 
 module.exports = server;

--- a/frontend/src/containers/Upload/UploadGridContainer.js
+++ b/frontend/src/containers/Upload/UploadGridContainer.js
@@ -53,7 +53,7 @@ class UploadGridContainer extends Component {
     };
 
     handleSubmit = () => {
-        const { grid, user, submitSubmission, submitDmpSubmission } = this.props;
+        const { grid, user, submitSubmission, submitDmpSubmission, submitLargeSubmission } = this.props;
         const formValues = this.props[grid.gridType].form.selected;
 
         const match = util.checkGridAndForm(formValues, grid.form);
@@ -78,6 +78,8 @@ class UploadGridContainer extends Component {
                         .then((decision) => decision && submitDmpSubmission(reviewed));
                 }
                 return submitDmpSubmission();
+            } else if (grid.rows.length > 50) {
+                return submitLargeSubmission();
             } else return submitSubmission();
         }
     };

--- a/frontend/src/redux/actions/submission/submissionActions.js
+++ b/frontend/src/redux/actions/submission/submissionActions.js
@@ -174,9 +174,34 @@ export function submitSubmission() {
     dispatch({ type: SUBMIT, message: 'Submitting...' });
 
     let data = util.generateSubmitData(getState());
-    console.log(data);
+    console.log(`Submitting a regular request ${data}`);
     services
       .submitSubmission(data)
+      .then(() => {
+        dispatch({
+          type: SUBMIT_SUCCESS,
+          message: 'clear',
+        });
+        return swal.submitSuccess();
+      })
+      .catch((error) => {
+        dispatch({
+          type: SUBMIT_FAIL,
+          error: error,
+        });
+        return error;
+      });
+  };
+}
+
+export function submitLargeSubmission() {
+  return (dispatch, getState) => {
+    dispatch({ type: SUBMIT, message: 'Submitting a large request, please allow for extra processing time...' });
+
+    let data = util.generateSubmitData(getState(), false, true);
+    console.log(`Submitting a large request ${data}`);
+    services
+      .submitLargeSubmission(data)
       .then(() => {
         dispatch({
           type: SUBMIT_SUCCESS,

--- a/frontend/src/redux/actions/submission/submissionActions.js
+++ b/frontend/src/redux/actions/submission/submissionActions.js
@@ -174,6 +174,7 @@ export function submitSubmission() {
     dispatch({ type: SUBMIT, message: 'Submitting...' });
 
     let data = util.generateSubmitData(getState());
+    console.log(data);
     services
       .submitSubmission(data)
       .then(() => {

--- a/frontend/src/redux/actions/submission/submissionActions.js
+++ b/frontend/src/redux/actions/submission/submissionActions.js
@@ -193,7 +193,7 @@ export function submitSubmission() {
   };
 }
 
-export async function submitLargeSubmission() {
+export function submitLargeSubmission() {
   return (dispatch, getState) => {
     dispatch({ type: SUBMIT, message: 'Submitting a large request, please allow for extra processing time...' });
 

--- a/frontend/src/redux/actions/submission/submissionActions.js
+++ b/frontend/src/redux/actions/submission/submissionActions.js
@@ -174,7 +174,6 @@ export function submitSubmission() {
     dispatch({ type: SUBMIT, message: 'Submitting...' });
 
     let data = util.generateSubmitData(getState());
-    console.log(`Submitting a regular request ${data}`);
     services
       .submitSubmission(data)
       .then(() => {
@@ -194,12 +193,11 @@ export function submitSubmission() {
   };
 }
 
-export function submitLargeSubmission() {
+export async function submitLargeSubmission() {
   return (dispatch, getState) => {
     dispatch({ type: SUBMIT, message: 'Submitting a large request, please allow for extra processing time...' });
 
     let data = util.generateSubmitData(getState(), false, true);
-    console.log(`Submitting a large request ${data}`);
     services
       .submitLargeSubmission(data)
       .then(() => {

--- a/frontend/src/redux/actions/submission/submissionActions.js
+++ b/frontend/src/redux/actions/submission/submissionActions.js
@@ -195,7 +195,7 @@ export function submitSubmission() {
 
 export function submitLargeSubmission() {
   return (dispatch, getState) => {
-    dispatch({ type: SUBMIT, message: 'Submitting a large request, please allow for extra processing time...' });
+    dispatch({ type: SUBMIT, message: 'Submitting a large request, please allow for extra processing time...', loading: true });
 
     let data = util.generateSubmitData(getState(), false, true);
     services

--- a/frontend/src/util/helpers.js
+++ b/frontend/src/util/helpers.js
@@ -206,7 +206,7 @@ export const generateAdditionalRowData = (columnFeatures, formValues, prevRowNum
 
 // generate data object to send to sample-rec-backend for
 // partial submission save or banked sample
-export const generateSubmitData = (state, isPartial = false) => {
+export const generateSubmitData = (state, isPartial = false, isLargeSampleSet = false) => {
   let data = {
     submissionType: '',
     gridValues: '',
@@ -220,8 +220,14 @@ export const generateSubmitData = (state, isPartial = false) => {
   }
 
   let rowsWithIndex = rowsWithRowIndex(state.upload.grid.rows);
+  // dont stringify yet if dataset is too large - we have to chunk the data so we dont timeout
+  if (isLargeSampleSet) {
+    data.gridValues = rowsWithIndex;
+  } else {
+    data.gridValues = JSON.stringify(rowsWithIndex);
+  }
+  
   data.submissionType = state.upload.grid.gridType;
-  data.gridValues = JSON.stringify(rowsWithIndex);
   data.formValues = JSON.stringify(state.upload.grid.form);
 
   return data;

--- a/frontend/src/util/services.js
+++ b/frontend/src/util/services.js
@@ -2,7 +2,6 @@ import axios from 'axios';
 import { Config } from '../config.js';
 
 axios.defaults.withCredentials = true;
-axios.defaults.timeout = 300000;
 
 // Add a request interceptor
 // axios.interceptors.request.use(
@@ -246,7 +245,8 @@ export const submitLargeSubmission = (data) => {
         promiseArray.push(axios({
             url: url,
             method: 'post',
-            data: fullDataChunkToSend
+            data: fullDataChunkToSend,
+            timeout: 300000
          }));
     }
     Promise.all(promiseArray)

--- a/frontend/src/util/services.js
+++ b/frontend/src/util/services.js
@@ -241,7 +241,7 @@ export const submitLargeSubmission = (data) => {
         const chunk = gridDataArray.slice(i, i + chunkSize);
         const stringifiedChunk = JSON.stringify(chunk);
         const fullDataChunkToSend = { ...data, gridValues: stringifiedChunk };
-        console.log(`Chunk to Send: ${stringifiedChunk}`);
+        // console.log(`Chunk to Send: ${stringifiedChunk}`);
         promiseArray.push(axios({
             url: url,
             method: 'post',

--- a/frontend/src/util/services.js
+++ b/frontend/src/util/services.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { Config } from '../config.js';
 
 axios.defaults.withCredentials = true;
+axios.defaults.timeout = 300000;
 
 // Add a request interceptor
 // axios.interceptors.request.use(

--- a/frontend/src/util/services.js
+++ b/frontend/src/util/services.js
@@ -232,7 +232,7 @@ export const submitSubmission = (data) => {
         });
 };
 
-export const submitLargeSubmission = (data) => {
+export const submitLargeSubmission = async (data) => {
     const url = `${Config.NODE_API_ROOT}/submission/submit`;
     const gridDataArray = data.gridValues;
     const chunkSize = 50;
@@ -241,7 +241,7 @@ export const submitLargeSubmission = (data) => {
         const chunk = gridDataArray.slice(i, i + chunkSize);
         const stringifiedChunk = JSON.stringify(chunk);
         const fullDataChunkToSend = { ...data, gridValues: stringifiedChunk };
-        console.log(`Chunk to Send: ${fullDataChunkToSend}`);
+        console.log(`Chunk to Send: ${stringifiedChunk}`);
         promiseArray.push(axios({
             url: url,
             method: 'post',
@@ -255,6 +255,9 @@ export const submitLargeSubmission = (data) => {
         .catch((error) => {
             console.log(error.response);
             throw error;
+        })
+        .then((response) => {
+            return response;
         });
 };
 

--- a/frontend/src/util/services.js
+++ b/frontend/src/util/services.js
@@ -232,6 +232,32 @@ export const submitSubmission = (data) => {
         });
 };
 
+export const submitLargeSubmission = (data) => {
+    const url = `${Config.NODE_API_ROOT}/submission/submit`;
+    const gridDataArray = data.gridValues;
+    const chunkSize = 50;
+    const promiseArray = [];
+    for (let i = 0; i < gridDataArray.length; i += chunkSize) {
+        const chunk = gridDataArray.slice(i, i + chunkSize);
+        const stringifiedChunk = JSON.stringify(chunk);
+        const fullDataChunkToSend = { ...data, gridValues: stringifiedChunk };
+        console.log(`Chunk to Send: ${fullDataChunkToSend}`);
+        promiseArray.push(axios({
+            url: url,
+            method: 'post',
+            data: fullDataChunkToSend
+         }));
+    }
+    Promise.all(promiseArray)
+        .then((responses) => {
+            return responses;
+        })
+        .catch((error) => {
+            console.log(error.response);
+            throw error;
+        });
+};
+
 export const deleteSubmission = (id, submissionType) => {
     const url = `${Config.NODE_API_ROOT}/submission/delete`;
     return axios

--- a/frontend/src/util/services.js
+++ b/frontend/src/util/services.js
@@ -249,7 +249,7 @@ export const submitLargeSubmission = (data) => {
             timeout: 300000
          }));
     }
-    Promise.all(promiseArray)
+    return Promise.all(promiseArray)
         .then((responses) => {
             return responses;
         })

--- a/frontend/src/util/services.js
+++ b/frontend/src/util/services.js
@@ -232,7 +232,7 @@ export const submitSubmission = (data) => {
         });
 };
 
-export const submitLargeSubmission = async (data) => {
+export const submitLargeSubmission = (data) => {
     const url = `${Config.NODE_API_ROOT}/submission/submit`;
     const gridDataArray = data.gridValues;
     const chunkSize = 50;


### PR DESCRIPTION
For submissions containing > 50 samples, we are now 'chunking' them and sending multiple separate requests at the same time.

Adjusted UI to show loading screen.

ALSO NEEDS AN NGINX UPDATE TO EXTEND REQUEST TIME:
  proxy_connect_timeout       600;
  proxy_send_timeout          600;
  proxy_read_timeout          600;
  send_timeout                600;

